### PR TITLE
Update goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,20 +3,20 @@ builds:
     binary: golinks
     main: .
     flags: -tags "static_build"
-    ldflags: -w -X github.com/prologic/golinks/.Version={{.Version}} -X github.com/prologic/golinks/.Commit={{.Commit}}
+    ldflags: -w -X main.Version={{.Version}} -X main.Commit={{.Commit}}
     env:
       - CGO_ENABLED=0
     hooks:
       pre: rice embed-go
-sign:
-  artifacts: checksum
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+signs:
+  - artifacts: checksum
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
There are two changes here:
- update config according to [deprecation noticies](https://goreleaser.com/deprecations/)
- fix `ldflags` so that version and commit specification actually updates version and commit

As mentioned in https://github.com/prologic/golinks/issues/28#issuecomment-714543335, `ldflags` is being a pain to work with and `goreleaser` changed config syntax. 

I tested this locally with `--skip-publish` and `--skip-validate`, then running `golinks_<blah-blah> -v`, but would appreciate it double-checked by someone else, because I am not using `goreleaser` on a regular basis.