### PR TITLE
[WIP] An example implementation of a "history" feature

### DIFF
--- a/history.go
+++ b/history.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type HistoryEntry struct {
+	Timestamp int64  `json:"timestamp"`
+	Command   string `json:"command"`
+	Value     string `json:"value"`
+}
+
+type HTMLHistoryEntry struct {
+	When string
+	What string
+}
+
+func AddHistoryEntry(command, value string) error {
+	ts := time.Now().UnixNano()
+	historyEntry := HistoryEntry{
+		Timestamp: ts,
+		Command:   command,
+		Value:     value,
+	}
+	key := BuildHistoryKey(ts)
+	b, err := json.Marshal(historyEntry)
+	if err != nil {
+		return err
+	}
+	if err := db.Put(key, b); err != nil {
+		return err
+	}
+	return nil
+}
+
+func BuildHistoryKey(timestamp int64) []byte {
+	return []byte(fmt.Sprintf("history_%d", timestamp))
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
       <section class="navbar-section">
         <a href="/" class="navbar-brand mr-10">Golinks</a>
         <a href="/help" class="btn btn-link">Help</a>
+        <a href="/history" class="btn btn-link">History</a>
       </section>
       <section class="navbar-section"></section>
     </header>

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,25 @@
+{{define "content"}}
+<section class="container">
+  <div class="columns">
+    <div class="column">
+      <h2 class="mt-2 mb-1">History</h2>
+      <table class="table">
+        <thead>
+        <tr>
+          <th>When</th>
+          <th class="text-left">What</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{ range .Entries }}
+          <tr>
+            <td style="width: 30%">{{ .When }}</td>
+            <td><code>{{ .What }}</code></td>
+          </tr>
+        {{ end }}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+{{end}}


### PR DESCRIPTION
This is a simple history of commands and bookmarks. #27 

The idea is to have a `history_` prefix in bitcask and add a unix nano timestamp at the end. 

There is a `/history` handler, which scans all entries, reverses them and displays in a table. And here is how it looks:

<img width="674" alt="history" src="https://user-images.githubusercontent.com/3424811/97789145-1afe8480-1bcf-11eb-9ee8-61d240f6158f.png">

There is a couple of ways to improve:

- add pagination based on timestamp (because database might grow significantly)
- have a `Scan` that scans in the reversed order, if "order" is actually something bitcask can provide
- add tests

Basically this is just something to start a discussion about. Please leave your comments.