### PR TITLE
make -v option work, strip binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 CGO_ENABLED=0
 COMMIT=`git rev-parse --short HEAD`
+VERSION=`git describe --abbrev=0 --tags`
 APP=golinks
 REPO?=prologic/$(APP)
 TAG?=latest
@@ -20,7 +21,7 @@ deps:
 build: clean deps
 	@echo " -> Building $(TAG)$(BUILD)"
 	@go build -tags "netgo static_build" -installsuffix netgo \
-		-ldflags "-w -X github.com/$(REPO).GitCommit=$(COMMIT) -X github.com/$(REPO).Build=$(BUILD)" .
+		-ldflags "-s -w -X main.Commit=$(COMMIT) -X main.Version=${VERSION}" .
 	@echo "Built $$(./$(APP) -v)"
 
 image:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/prologic/golinks
 
 require (
-	github.com/GeertJohan/go.rice v1.0.0
+	github.com/GeertJohan/go.rice v1.0.2
 	github.com/NYTimes/gziphandler v1.0.1
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/namsral/flag v1.7.4-pre

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0 h1:KkI6O9uMaQU3VEKaj01ulavtF7o1fWT7+pk/4voiMLQ=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
+github.com/GeertJohan/go.rice v1.0.2 h1:PtRw+Tg3oa3HYwiDBZyvOJ8LdIyf6lAovJJtr7YOAYk=
+github.com/GeertJohan/go.rice v1.0.2/go.mod h1:af5vUNlDNkCjOZeSGFgIJxDje9qdjsO6hshx0gTmZt4=
 github.com/NYTimes/gziphandler v1.0.1 h1:iLrQrdwjDd52kHDA5op2UBJFjmOb9g+7scBan4RN8F0=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -79,6 +81,8 @@ github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZ
 github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229 h1:E2B8qYyeSgv5MXpmzZXRNp8IAQ4vjxIjhpAf5hv/tAg=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
+github.com/nkovacs/streamquote v1.0.0 h1:PmVIV08Zlx2lZK5fFZlMZ04eHcDTIFJCv/5/0twVUow=
+github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=


### PR DESCRIPTION
we use `-ldflags "-X  importpath.value"` option to modify the value of the Version and Commit variable defined in [version.go](https://github.com/prologic/golinks/blob/master/version.go), so the import path should be main, not "github.com/$(REPO).GitCommit"

to test it works or not, I'm using Windows10 and git-bash, in the project root directory, just type `make`:
```sh
 /d/golang/src/github.com/prologic/golinks (master)
$ make
Removing golinks.exe
Removing rice-box.go
Removing search.db/
go: found github.com/GeertJohan/go.rice/rice in github.com/GeertJohan/go.rice v1.0.2
 -> Building latest-dev
Built golinks-v0.0.5@57470ba
2020/12/26 11:23:27 golinks-v0.0.5@57470ba listening on http://0.0.0.0:8000
```
the version and commit hash value has been passed into the program



and I added [-ldflags "-s"](https://golang.org/cmd/link/) option to make binary executable file smaller, to prove this, I do the below instructions on the same environment:
1. without `-ldflags "-s"` in makefile
```sh
make 
......
ls -sialh golinks.exe
2533274791500462 8.6M -rwxr-xr-x 1 g00455772 1049089 8.6M Dec 26 11:27 golinks.exe*
```
2.  with  `-ldflags "-s"` in makefile
```sh
make
.....
ls -sialh golinks.exe
2814749768211118 8.0M -rwxr-xr-x 1 g00455772 1049089 8.0M Dec 26 11:28 golinks.exe*
```

we save **0.6MB** disk space!





 